### PR TITLE
Add logging and benchmarking to scripts

### DIFF
--- a/sbx_sga.smk
+++ b/sbx_sga.smk
@@ -62,6 +62,10 @@ rule shovill_summary:
         contigs=ISOLATE_FP / "shovill" / "{sample}" / "{sample}.fa",
     output:
         statistics=ISOLATE_FP / "shovill" / "{sample}" / "parsed_summary.tsv",
+    log:
+        LOG_FP / "sga_shovill_summary_{sample}.log",
+    benchmark:
+        BENCHMARK_FP / "sga_shovill_summary_{sample}.tsv"
     script:
         "scripts/shovill.py"
 
@@ -77,6 +81,10 @@ rule combine_shovill_summary:
     params:
         suffix="",
         header=True,
+    log:
+        LOG_FP / "sga_combine_shovill_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_combine_shovill_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -223,6 +231,10 @@ rule mash_summary:
         sorted_reports=ISOLATE_FP / "mash" / "{sample}" / "{sample}_sorted_winning.tab",
     output:
         summary=ISOLATE_FP / "mash" / "{sample}" / "{sample}_summary.tsv",
+    log:
+        LOG_FP / "sga_mash_summary_{sample}.log",
+    benchmark:
+        BENCHMARK_FP / "sga_mash_summary_{sample}.tsv"
     script:
         "scripts/mash.py"
 
@@ -269,6 +281,10 @@ rule mlst_parse:
         reports=ISOLATE_FP / "mlst" / "{sample}" / "{sample}.mlst",
     output:
         mlst_report=ISOLATE_FP / "mlst" / "{sample}" / "parsed_mlst.txt",
+    log:
+        LOG_FP / "sga_mlst_parse_{sample}.log",
+    benchmark:
+        BENCHMARK_FP / "sga_mlst_parse_{sample}.tsv"
     script:
         "scripts/mlst.py"
 
@@ -283,6 +299,10 @@ rule mlst_summary:
     params:
         suffix="",
         header=True,
+    log:
+        LOG_FP / "sga_mlst_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_mlst_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -320,6 +340,10 @@ rule parse_bakta_report:
         bakta=ISOLATE_FP / "bakta" / "{sample}" / "{sample}.txt",
     output:
         parsed_report=ISOLATE_FP / "bakta" / "{sample}" / "parsed_summary.tsv",
+    log:
+        LOG_FP / "sga_bakta_parse_{sample}.log",
+    benchmark:
+        BENCHMARK_FP / "sga_bakta_parse_{sample}.tsv"
     script:
         "scripts/bakta.py"
 
@@ -334,6 +358,10 @@ rule combine_bakta_summary:
     params:
         suffix="",
         header=True,
+    log:
+        LOG_FP / "sga_combine_bakta_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_combine_bakta_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -375,6 +403,10 @@ rule abritamr_summary:
     params:
         suffix="",
         header=True,
+    log:
+        LOG_FP / "sga_abritamr_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_abritamr_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -387,6 +419,10 @@ rule all_summary:
         final_report=ISOLATE_FP / "final_summary.tsv",
     params:
         tools=TOOLS,
+    log:
+        LOG_FP / "sga_all_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_all_summary.tsv"
     script:
         "scripts/summarize_all.py"
 

--- a/sbx_sga_snippy.smk
+++ b/sbx_sga_snippy.smk
@@ -84,5 +84,9 @@ rule snippy_summary:
     params:
         suffix="",
         header=True,
+    log:
+        LOG_FP / "sga_snippy_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_snippy_summary.tsv"
     script:
         "scripts/concat_files.py"

--- a/sbx_sga_virus.smk
+++ b/sbx_sga_virus.smk
@@ -110,6 +110,10 @@ rule sga_plasmid_classification_summary:
     params:
         suffix="_summary",
         header=True,
+    log:
+        LOG_FP / "sga_plasmid_classification_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_plasmid_classification_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -132,6 +136,10 @@ rule sga_phage_classification_summary:
     params:
         suffix="_summary",
         header=True,
+    log:
+        LOG_FP / "sga_phage_classification_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_phage_classification_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -152,6 +160,10 @@ rule sga_plasmid_gene_summary:
     params:
         suffix="_summary",
         header=True,
+    log:
+        LOG_FP / "sga_plasmid_gene_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_plasmid_gene_summary.tsv"
     script:
         "scripts/concat_files.py"
 
@@ -172,5 +184,9 @@ rule sga_virus_gene_summary:
     params:
         suffix="_summary",
         header=True,
+    log:
+        LOG_FP / "sga_virus_gene_summary.log",
+    benchmark:
+        BENCHMARK_FP / "sga_virus_gene_summary.tsv"
     script:
         "scripts/concat_files.py"

--- a/scripts/bakta.py
+++ b/scripts/bakta.py
@@ -1,7 +1,15 @@
 import sys
+
 from bakta_f import write_to_report
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[bakta.py] {message}\n")
+
 
 report = snakemake.input[0]
 output = snakemake.output[0]
 
+log(f"Starting write_to_report with report={report} -> output={output}")
 write_to_report(report, output)
+log(f"Finished writing parsed Bakta summary to {output}")

--- a/scripts/bakta_f.py
+++ b/scripts/bakta_f.py
@@ -3,7 +3,12 @@ import os
 import csv
 
 
+def log(message: str) -> None:
+    sys.stderr.write(f"[bakta_f] {message}\n")
+
+
 def parse_file(filelines):
+    log(f"Parsing {len(filelines)} raw lines from Bakta report")
     parsed_dict = {}
     if len(filelines) != 0:
         for line in filelines:
@@ -14,6 +19,7 @@ def parse_file(filelines):
             except:
                 continue
             parsed_dict[key] = value
+            log(f"Captured entry key={key!r} value={value!r}")
     return parsed_dict
 
 
@@ -23,7 +29,12 @@ def test_parse():
 
 
 def filter_keys(parsed_dict):
-    return {key: value for key, value in parsed_dict.items() if value != ""}
+    filtered = {key: value for key, value in parsed_dict.items() if value != ""}
+    log(
+        "Filtered parsed entries: "
+        f"kept {len(filtered)} of {len(parsed_dict)} keys with non-empty values"
+    )
+    return filtered
 
 
 def test_filter():
@@ -32,6 +43,7 @@ def test_filter():
 
 
 def write_to_report(report_fp, output_fp):
+    log(f"Opening Bakta report at {report_fp}")
     with open(report_fp, "r") as f_in:
         lines = f_in.readlines()
 
@@ -42,3 +54,6 @@ def write_to_report(report_fp, output_fp):
         writer = csv.writer(op, delimiter="\t")
         writer.writerow(filtered.keys())
         writer.writerow(filtered.values())
+    log(
+        f"Wrote Bakta summary with {len(filtered)} keys to {output_fp}"
+    )

--- a/scripts/concat_files.py
+++ b/scripts/concat_files.py
@@ -1,8 +1,27 @@
+import sys
+
 from concat_files_f import summarize_all
 
-summarize_all(
-    snakemake.input,
-    snakemake.output[0],
-    snakemake.params.suffix,
-    snakemake.params.header,
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[concat_files.py] {message}\n")
+
+
+input_files = list(snakemake.input)
+output_path = snakemake.output[0]
+suffix = snakemake.params.suffix
+header = snakemake.params.header
+
+log(
+    "Starting summarize_all with "
+    f"{len(input_files)} files, suffix={suffix!r}, header={header} -> {output_path}"
 )
+
+summarize_all(
+    input_files,
+    output_path,
+    suffix,
+    header,
+)
+
+log(f"Finished summarizing files into {output_path}")

--- a/scripts/concat_files_f.py
+++ b/scripts/concat_files_f.py
@@ -1,20 +1,32 @@
 import os
 import csv
+import sys
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[concat_files_f] {message}\n")
 
 
 def write_report(writer, report_reader, sample_name):
+    log(f"Writing rows for sample {sample_name}")
     for row in report_reader:
         row.insert(0, sample_name)
         writer.writerow(row)
 
 
 def summarize_all(report_paths, out_fp, folder_suffix="", header=True):
+    log(
+        "Preparing to summarize "
+        f"{len(report_paths)} reports to {out_fp} (header={header})"
+    )
     first_non_empty = True
     header_first = []
     with open(out_fp, "w") as out_f:
         writer = csv.writer(out_f, delimiter="\t")
         for report_path in report_paths:
+            log(f"Processing report {report_path}")
             if os.path.getsize(report_path) < 5:
+                log(f"Skipping {report_path} because file is nearly empty")
                 continue
             sample_name = os.path.basename(os.path.dirname(report_path))
             sample_name = sample_name.removesuffix(folder_suffix)
@@ -24,14 +36,16 @@ def summarize_all(report_paths, out_fp, folder_suffix="", header=True):
                     header_line = next(report_reader)
                     header_line.insert(0, "SampleID")
                     if first_non_empty:
+                        log(f"Setting header to {header_line}")
                         header_first = header_line
                         writer.writerow(header_first)
                     else:
                         if header_line != header_first:
-                            print(header_line)
-                            print(header_first)
+                            log(f"Header mismatch for sample {sample_name}: {header_line}")
+                            log(f"Expected header: {header_first}")
                             raise ValueError(
                                 f"Headers in sample {sample_name} doesn't match the first file"
                             )
                 write_report(writer, report_reader, sample_name)
             first_non_empty = False
+    log(f"Finished writing combined report to {out_fp}")

--- a/scripts/mash.py
+++ b/scripts/mash.py
@@ -1,15 +1,34 @@
 import sys
-from scripts.mash_f import open_report, parse_report, contamination_call, write_report
+
+from scripts.mash_f import (
+    open_report,
+    parse_report,
+    contamination_call,
+    write_report,
+)
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[mash.py] {message}\n")
+
 
 sorted_report = snakemake.input[0]
 output = snakemake.output[0]
 
+log(f"Starting Mash summary for {sorted_report} -> {output}")
+
 sample, filelines = open_report(sorted_report)
+log(f"Loaded {len(filelines)} candidate lines for sample {sample}")
 
 if len(filelines) == 0:
     empty_dict = {"": ""}
+    log("No lines found in report; writing empty summary")
     write_report(output, sample, empty_dict)
 else:
     parsed_report = parse_report(filelines)
+    log(f"Parsed {len(parsed_report)} contamination entries")
     mash_dict = contamination_call(parsed_report)
+    log(f"Contamination call result: {mash_dict}")
     write_report(output, sample, mash_dict)
+
+log(f"Finished Mash summary for sample {sample}")

--- a/scripts/mash_f.py
+++ b/scripts/mash_f.py
@@ -3,11 +3,19 @@ import os
 import sys
 
 
+def log(message: str) -> None:
+    sys.stderr.write(f"[mash_f] {message}\n")
+
+
 def open_report(report):
     sample_name = os.path.basename(report.split("_sorted_winning.tab")[0])
     with open(report, "r") as report_obj:
         filelines = report_obj.readlines()
     top_lines = filelines[:20]
+    log(
+        f"Opened report {report} for sample {sample_name}; "
+        f"total_lines={len(filelines)}, taking top {len(top_lines)}"
+    )
     return sample_name, top_lines
 
 
@@ -26,13 +34,19 @@ def process_mash_line(line):
     median_multiplicity = float(line_list[2])
     identity = float(line_list[0])
     hits = int(line_list[1].split("/")[0])
+    log(
+        "Processed mash line with species="
+        f"{species}, identity={identity}, hits={hits}, median_multiplicity={median_multiplicity}"
+    )
     return species, median_multiplicity, identity, hits
 
 
 def get_first_non_phage_hit(lines):
     for idx, line in enumerate(lines):
         if "phage" not in line.lower():
+            log(f"Found first non-phage hit at index {idx}")
             return process_mash_line(line), idx
+    log("No non-phage hits detected in top lines")
     return None, None
 
 
@@ -42,6 +56,7 @@ def parse_report(top_lines):
     result = get_first_non_phage_hit(top_lines)
 
     if result == (None, None):
+        log("parse_report returning empty set due to lack of non-phage hits")
         return set()
 
     # Get top non-phage hit and its index
@@ -49,9 +64,11 @@ def parse_report(top_lines):
 
     if (top_identity >= 0.85) and (top_hits >= 100):
         target_species.append(top_species)
+        log(f"Top hit passes thresholds: {top_species}")
 
     # Set the threshold for median multiplicity
     threshold = 0.05 * top_median_multiplicity
+    log(f"Median multiplicity threshold set to {threshold}")
 
     # Iterate through the rest of the hits, excluding top_index
     for i, line in enumerate(top_lines):
@@ -63,8 +80,11 @@ def parse_report(top_lines):
                 continue
             if median_multiplicity >= threshold:
                 target_species.append(species)
+                log(f"Adding additional species {species}")
 
-    return set(target_species)
+    result_set = set(target_species)
+    log(f"parse_report returning {result_set}")
+    return result_set
 
 
 def contamination_call(target_set):
@@ -74,6 +94,7 @@ def contamination_call(target_set):
     else:
         species = " ".join(sorted(target_set))
         mash_dict["Contaminated"] = species
+    log(f"contamination_call produced {mash_dict}")
     return mash_dict
 
 
@@ -86,10 +107,12 @@ def write_report(output, sample_name, mash_dict):
         raise ValueError(
             f"Expected mash_dict to have exactly one key-value pair, but got {len(mash_dict)}."
         )
+    log(f"Writing Mash report for {sample_name} with status={status}")
     with open(output, "w") as out:
         if status == "Contaminated":
             contaminated_spp = mash_dict[status]
             out.write(f"{sample_name}\tContaminated\t{contaminated_spp}\n")
         else:
             out.write(f"{sample_name}\tNA\tNA\n")
+    log(f"Completed writing Mash report to {output}")
     return output

--- a/scripts/mlst.py
+++ b/scripts/mlst.py
@@ -1,7 +1,17 @@
 import sys
+
 from mlst_f import write_to_report
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[mlst.py] {message}\n")
+
 
 report = snakemake.input[0]
 output = snakemake.output[0]
 
+log(f"Starting MLST parsing for report={report} -> output={output}")
+
 write_to_report(report, output)
+
+log(f"Finished MLST parsing for {report}")

--- a/scripts/mlst_f.py
+++ b/scripts/mlst_f.py
@@ -1,15 +1,25 @@
 import csv
+import sys
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[mlst_f] {message}\n")
 
 
 def smush_column(line):
     line_parsed = []
-    print(line)
+    log(f"Processing MLST line: {line}")
     if line:
         schema = line[1]
         st = line[2]
         alleles = line[3:]
         alleles_joined = " ".join(alleles)
         line_parsed = [schema, st, alleles_joined]
+        log(
+            "Extracted schema={schema}, st={st}, allele_count={count}".format(
+                schema=schema, st=st, count=len(alleles)
+            )
+        )
     return line_parsed
 
 
@@ -31,6 +41,7 @@ def test_smush_column():
 
 
 def write_to_report(report, output):
+    log(f"Writing MLST summary from {report} to {output}")
     with open(report, "r") as f_in:
         reader = csv.reader(f_in, delimiter="\t")
         with open(output, "w") as op:
@@ -39,3 +50,4 @@ def write_to_report(report, output):
             for row in reader:
                 smushed_column = smush_column(row)
                 writer.writerow(smushed_column)
+    log(f"Completed MLST summary for {report}")

--- a/scripts/shovill.py
+++ b/scripts/shovill.py
@@ -1,5 +1,15 @@
+import sys
+
 from shovill_f import write_shovill_stats
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[shovill.py] {message}\n")
+
 
 genome = snakemake.input[0]
 output = snakemake.output[0]
+
+log(f"Starting Shovill stats calculation for genome={genome} -> output={output}")
 write_shovill_stats(genome, output)
+log(f"Finished Shovill stats calculation for {genome}")

--- a/scripts/shovill_f.py
+++ b/scripts/shovill_f.py
@@ -4,12 +4,18 @@ from io import StringIO
 import csv
 
 
+def log(message: str) -> None:
+    sys.stderr.write(f"[shovill_f] {message}\n")
+
+
 def get_fasta_headers(f_in):
     headers = []
     for line in f_in:
         if line.startswith(">"):
             line = line.strip()
             headers.append(line)
+            log(f"Found header: {line}")
+    log(f"Total headers parsed: {len(headers)}")
     return headers
 
 
@@ -26,7 +32,9 @@ def parse_header(header):
     header_dict["len"] = int(header_dict["len"])
     header_dict["cov"] = float(header_dict["cov"])
     keys_of_interest = ["len", "cov"]
-    return {key: header_dict[key] for key in keys_of_interest if key in header_dict}
+    parsed = {key: header_dict[key] for key in keys_of_interest if key in header_dict}
+    log(f"Parsed header into {parsed}")
+    return parsed
 
 
 def test_parse_header():
@@ -49,7 +57,12 @@ def calc_cov_stats(contig_stats):
     avg_cov = sum(c["len"] * c["cov"] for c in contig_stats) / total_length
 
     rounded_cov = round(avg_cov, 2)
-    return [total_ctgs, min_cov, max_cov, rounded_cov]
+    stats = [total_ctgs, min_cov, max_cov, rounded_cov]
+    log(
+        "Calculated coverage stats: "
+        f"total_contigs={total_ctgs}, min={min_cov}, max={max_cov}, mean={rounded_cov}"
+    )
+    return stats
 
 
 def test_calc_cov_stats():
@@ -58,6 +71,7 @@ def test_calc_cov_stats():
 
 
 def write_shovill_stats(fp_in, fp_out):
+    log(f"Writing Shovill statistics from {fp_in} to {fp_out}")
     with open(fp_in, "r") as f_in:
         headers = get_fasta_headers(f_in)
 
@@ -72,5 +86,7 @@ def write_shovill_stats(fp_in, fp_out):
                 contig_stats.append(parse_header(header))
             final_stats = calc_cov_stats(contig_stats)
             writer.writerow(final_stats)
+            log(f"Wrote stats row: {final_stats}")
         else:
             writer.writerow([0, 0, 0, 0])
+            log("No headers found; wrote zero stats")

--- a/scripts/summarize_all.py
+++ b/scripts/summarize_all.py
@@ -1,25 +1,38 @@
 import pandas as pd
 from functools import reduce
 import os
+import sys
+
+
+def log(message: str) -> None:
+    sys.stderr.write(f"[summarize_all.py] {message}\n")
 
 
 def process_filelines(fp, columns):
+    log(f"Reading file {fp} with columns {columns}")
     df = pd.read_csv(fp, sep="\t")
     columns.insert(0, "SampleID")
+    log(f"Reordered columns for {fp}: {columns}")
     return df[columns]
 
 
 def summarize_all(input_files, output, tools):
+    log(
+        f"Starting summarize_all for {len(input_files)} files into {output}. "
+        f"Available tools: {list(tools.keys())}"
+    )
     if not input_files:
         # Handle empty input_files by writing an empty CSV with just the header
         empty_df = pd.DataFrame(columns=["SampleID"])
         empty_df.to_csv(output, index=False, sep="\t")
+        log("No input files provided; wrote empty summary")
         return
 
     master_list = []
     for fp in input_files:
         tool = os.path.splitext(os.path.basename(fp))[0]
         columns = tools[tool]
+        log(f"Processing tool {tool} for file {fp}")
         df = process_filelines(fp, columns)
         master_list.append(df)
 
@@ -28,6 +41,9 @@ def summarize_all(input_files, output, tools):
         master_list,
     )
     final_df.to_csv(output, index=False, sep="\t")
+    log(f"Finished writing combined summary to {output}")
 
 
+log("Invoked via Snakemake")
 summarize_all(snakemake.input, snakemake.output[0], snakemake.params.tools)
+log("Completed summarize_all Snakemake execution")


### PR DESCRIPTION
## Summary
- add stderr logging to each Snakemake script entrypoint to record inputs, outputs, and execution milestones
- instrument helper modules with additional debug output for parsing and summarization helpers
- register log and benchmark files for script-driven rules so Snakemake captures the messages

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68cc7925e60c83238d49084ba180327e