### PR TITLE
Allow helper modules to run without explicit logger

### DIFF
--- a/scripts/bakta_f.py
+++ b/scripts/bakta_f.py
@@ -3,7 +3,14 @@ from io import StringIO
 from typing import Callable
 
 
-def parse_file(filelines, log: Callable[[str], None]):
+def _noop_log(message: str) -> None:
+    """Default logger used when no log callable is supplied."""
+    pass
+
+
+
+
+def parse_file(filelines, log: Callable[[str], None] = _noop_log):
     log(f"[bakta_f] Parsing {len(filelines)} raw lines from Bakta report")
     parsed_dict = {}
     if len(filelines) != 0:
@@ -34,7 +41,7 @@ def test_parse():
     }
 
 
-def filter_keys(parsed_dict, log: Callable[[str], None]):
+def filter_keys(parsed_dict, log: Callable[[str], None] = _noop_log):
     filtered = {key: value for key, value in parsed_dict.items() if value != ""}
     log(
         "[bakta_f] Filtered parsed entries: "
@@ -53,7 +60,9 @@ def test_filter():
     assert filter_keys(test, test_log) == {"test": "9", "a": "10", "d": "1343"}
 
 
-def write_to_report(report_fp, output_fp, log: Callable[[str], None]):
+def write_to_report(
+    report_fp, output_fp, log: Callable[[str], None] = _noop_log
+):
     log(f"[bakta_f] Opening Bakta report at {report_fp}")
     with open(report_fp, "r") as f_in:
         lines = f_in.readlines()

--- a/scripts/concat_files_f.py
+++ b/scripts/concat_files_f.py
@@ -3,11 +3,16 @@ import os
 from typing import Callable, Iterable, Optional
 
 
+def _noop_log(message: str) -> None:
+    """Default logger that ignores messages when no logger is provided."""
+    pass
+
+
 def write_report(
     writer,
     report_reader: Iterable[list],
     sample_name: str,
-    log: Callable[[str], None],
+    log: Callable[[str], None] = _noop_log,
 ):
     log(f"[concat_files_f] Writing rows for sample {sample_name}")
     for row in report_reader:
@@ -23,7 +28,7 @@ def summarize_all(
     log: Optional[Callable[[str], None]] = None,
 ):
     if log is None:
-        raise ValueError("log must be provided for summarize_all")
+        log = _noop_log
 
     log(
         "[concat_files_f] Preparing to summarize "

--- a/scripts/mash_f.py
+++ b/scripts/mash_f.py
@@ -3,7 +3,14 @@ import re
 from typing import Callable, Iterable, Optional, Sequence, Set, Tuple
 
 
-def open_report(report: str, log: Callable[[str], None]) -> Tuple[str, Sequence[str]]:
+def _noop_log(message: str) -> None:
+    """Default logger that ignores messages when no logger is provided."""
+    pass
+
+
+def open_report(
+    report: str, log: Callable[[str], None] = _noop_log
+) -> Tuple[str, Sequence[str]]:
     sample_name = os.path.basename(report.split("_sorted_winning.tab")[0])
     with open(report, "r") as report_obj:
         filelines = report_obj.readlines()
@@ -16,7 +23,7 @@ def open_report(report: str, log: Callable[[str], None]) -> Tuple[str, Sequence[
 
 
 def process_mash_line(
-    line: str, log: Callable[[str], None]
+    line: str, log: Callable[[str], None] = _noop_log
 ) -> Tuple[str, float, float, int]:
     line_list = line.rstrip().split("\t")
     species_line = line_list[-1]
@@ -40,7 +47,7 @@ def process_mash_line(
 
 
 def get_first_non_phage_hit(
-    lines: Iterable[str], log: Callable[[str], None]
+    lines: Iterable[str], log: Callable[[str], None] = _noop_log
 ) -> Tuple[Optional[Tuple[str, float, float, int]], Optional[int]]:
     for idx, line in enumerate(lines):
         if "phage" not in line.lower():
@@ -50,7 +57,9 @@ def get_first_non_phage_hit(
     return None, None
 
 
-def parse_report(top_lines: Sequence[str], log: Callable[[str], None]) -> Set[str]:
+def parse_report(
+    top_lines: Sequence[str], log: Callable[[str], None] = _noop_log
+) -> Set[str]:
     target_species: Set[str] = set()
 
     result = get_first_non_phage_hit(top_lines, log)
@@ -86,7 +95,9 @@ def parse_report(top_lines: Sequence[str], log: Callable[[str], None]) -> Set[st
     return target_species
 
 
-def contamination_call(target_set: Set[str], log: Callable[[str], None]):
+def contamination_call(
+    target_set: Set[str], log: Callable[[str], None] = _noop_log
+):
     mash_dict = {}
     if len(target_set) <= 1:
         mash_dict["NA"] = ""
@@ -101,7 +112,7 @@ def write_report(
     output: str,
     sample_name: str,
     mash_dict,
-    log: Callable[[str], None],
+    log: Callable[[str], None] = _noop_log,
 ):
     # Expecting that the dictionary is just one key-value pair, so need to check that
     if len(mash_dict) == 1:

--- a/scripts/mlst_f.py
+++ b/scripts/mlst_f.py
@@ -3,7 +3,12 @@ from io import StringIO
 from typing import Callable
 
 
-def smush_column(line, log: Callable[[str], None]):
+def _noop_log(message: str) -> None:
+    """Default logger that ignores messages when no logger is provided."""
+    pass
+
+
+def smush_column(line, log: Callable[[str], None] = _noop_log):
     line_parsed = []
     log(f"[mlst_f] Processing MLST line: {line}")
     if line:
@@ -42,7 +47,7 @@ def test_smush_column():
     ]
 
 
-def write_to_report(report, output, log: Callable[[str], None]):
+def write_to_report(report, output, log: Callable[[str], None] = _noop_log):
     log(f"[mlst_f] Writing MLST summary from {report} to {output}")
     with open(report, "r") as f_in:
         reader = csv.reader(f_in, delimiter="\t")

--- a/scripts/shovill_f.py
+++ b/scripts/shovill_f.py
@@ -4,7 +4,14 @@ from io import StringIO
 from typing import Callable, Iterable, List
 
 
-def get_fasta_headers(f_in: Iterable[str], log: Callable[[str], None]) -> List[str]:
+def _noop_log(message: str) -> None:
+    """Default logger that ignores messages when no logger is provided."""
+    pass
+
+
+def get_fasta_headers(
+    f_in: Iterable[str], log: Callable[[str], None] = _noop_log
+) -> List[str]:
     headers = []
     for line in f_in:
         if line.startswith(">"):
@@ -27,7 +34,7 @@ def test_get_fasta_headers():
     assert headers == [">s1", ">s2"]
 
 
-def parse_header(header: str, log: Callable[[str], None]):
+def parse_header(header: str, log: Callable[[str], None] = _noop_log):
     header = header.split()[1:]  # gets rid of the contig name
     header_dict = dict(item.split("=") for item in header)
     header_dict["len"] = int(header_dict["len"])
@@ -60,7 +67,7 @@ def test_parse_header2():
     assert cov == {"len": 122482, "cov": 39}
 
 
-def calc_cov_stats(contig_stats, log: Callable[[str], None]):
+def calc_cov_stats(contig_stats, log: Callable[[str], None] = _noop_log):
     total_ctgs = len(contig_stats)
     min_cov = min(c["cov"] for c in contig_stats)
     max_cov = max(c["cov"] for c in contig_stats)
@@ -86,7 +93,9 @@ def test_calc_cov_stats():
     assert calc_cov_stats(d, test_log) == [2, 2, 10, 4.29]
 
 
-def write_shovill_stats(fp_in: str, fp_out: str, log: Callable[[str], None]):
+def write_shovill_stats(
+    fp_in: str, fp_out: str, log: Callable[[str], None] = _noop_log
+):
     log(f"[shovill_f] Writing Shovill statistics from {fp_in} to {fp_out}")
     if not os.path.exists(fp_in):
         raise FileNotFoundError(f"Input FASTA {fp_in} does not exist")


### PR DESCRIPTION
## Summary
- add default no-op loggers to helper modules so callers can omit the log argument
- update concat_files summarization helpers to fall back to the default logger when none is provided

## Testing
- `pytest .tests/unit/test_bakta.py .tests/unit/test_concat_files.py .tests/unit/test_mash.py .tests/unit/test_mlst.py .tests/unit/test_shovill.py`


------
https://chatgpt.com/codex/tasks/task_e_68ccbed46a288323ae9e4ed21a40ebfe