### PR TITLE
Improve error logging for Snakemake scripts

### DIFF
--- a/scripts/bakta.py
+++ b/scripts/bakta.py
@@ -1,3 +1,5 @@
+import traceback
+
 from bakta_f import write_to_report
 
 
@@ -10,6 +12,11 @@ with open(snakemake.log[0], "w") as log_file:
     report = snakemake.input[0]
     output = snakemake.output[0]
 
-    log(f"Starting write_to_report with report={report} -> output={output}")
-    write_to_report(report, output, log)
-    log(f"Finished writing parsed Bakta summary to {output}")
+    try:
+        log(f"Starting write_to_report with report={report} -> output={output}")
+        write_to_report(report, output, log)
+        log(f"Finished writing parsed Bakta summary to {output}")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise

--- a/scripts/concat_files.py
+++ b/scripts/concat_files.py
@@ -1,3 +1,5 @@
+import traceback
+
 from concat_files_f import summarize_all
 
 
@@ -12,17 +14,22 @@ with open(snakemake.log[0], "w") as log_file:
     suffix = snakemake.params.suffix
     header = snakemake.params.header
 
-    log(
-        "Starting summarize_all with "
-        f"{len(input_files)} files, suffix={suffix!r}, header={header} -> {output_path}"
-    )
+    try:
+        log(
+            "Starting summarize_all with "
+            f"{len(input_files)} files, suffix={suffix!r}, header={header} -> {output_path}"
+        )
 
-    summarize_all(
-        input_files,
-        output_path,
-        suffix,
-        header,
-        log,
-    )
+        summarize_all(
+            input_files,
+            output_path,
+            suffix,
+            header,
+            log,
+        )
 
-    log(f"Finished summarizing files into {output_path}")
+        log(f"Finished summarizing files into {output_path}")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise

--- a/scripts/mash.py
+++ b/scripts/mash.py
@@ -1,3 +1,5 @@
+import traceback
+
 from scripts.mash_f import (
     open_report,
     parse_report,
@@ -15,20 +17,25 @@ with open(snakemake.log[0], "w") as log_file:
     sorted_report = snakemake.input[0]
     output = snakemake.output[0]
 
-    log(f"Starting Mash summary for {sorted_report} -> {output}")
+    try:
+        log(f"Starting Mash summary for {sorted_report} -> {output}")
 
-    sample, filelines = open_report(sorted_report, log)
-    log(f"Loaded {len(filelines)} candidate lines for sample {sample}")
+        sample, filelines = open_report(sorted_report, log)
+        log(f"Loaded {len(filelines)} candidate lines for sample {sample}")
 
-    if len(filelines) == 0:
-        empty_dict = {"": ""}
-        log("No lines found in report; writing empty summary")
-        write_report(output, sample, empty_dict, log)
-    else:
-        parsed_report = parse_report(filelines, log)
-        log(f"Parsed {len(parsed_report)} contamination entries")
-        mash_dict = contamination_call(parsed_report, log)
-        log(f"Contamination call result: {mash_dict}")
-        write_report(output, sample, mash_dict, log)
+        if len(filelines) == 0:
+            empty_dict = {"": ""}
+            log("No lines found in report; writing empty summary")
+            write_report(output, sample, empty_dict, log)
+        else:
+            parsed_report = parse_report(filelines, log)
+            log(f"Parsed {len(parsed_report)} contamination entries")
+            mash_dict = contamination_call(parsed_report, log)
+            log(f"Contamination call result: {mash_dict}")
+            write_report(output, sample, mash_dict, log)
 
-    log(f"Finished Mash summary for sample {sample}")
+        log(f"Finished Mash summary for sample {sample}")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise

--- a/scripts/mlst.py
+++ b/scripts/mlst.py
@@ -1,3 +1,5 @@
+import traceback
+
 from mlst_f import write_to_report
 
 
@@ -10,8 +12,13 @@ with open(snakemake.log[0], "w") as log_file:
     report = snakemake.input[0]
     output = snakemake.output[0]
 
-    log(f"Starting MLST parsing for report={report} -> output={output}")
+    try:
+        log(f"Starting MLST parsing for report={report} -> output={output}")
 
-    write_to_report(report, output, log)
+        write_to_report(report, output, log)
 
-    log(f"Finished MLST parsing for {report}")
+        log(f"Finished MLST parsing for {report}")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise

--- a/scripts/shovill.py
+++ b/scripts/shovill.py
@@ -1,3 +1,5 @@
+import traceback
+
 from shovill_f import write_shovill_stats
 
 
@@ -10,6 +12,11 @@ with open(snakemake.log[0], "w") as log_file:
     genome = snakemake.input[0]
     output = snakemake.output[0]
 
-    log(f"Starting Shovill stats calculation for genome={genome} -> output={output}")
-    write_shovill_stats(genome, output, log)
-    log(f"Finished Shovill stats calculation for {genome}")
+    try:
+        log(f"Starting Shovill stats calculation for genome={genome} -> output={output}")
+        write_shovill_stats(genome, output, log)
+        log(f"Finished Shovill stats calculation for {genome}")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise

--- a/scripts/summarize_all.py
+++ b/scripts/summarize_all.py
@@ -1,4 +1,5 @@
 import os
+import traceback
 from functools import reduce
 from typing import Callable
 
@@ -48,6 +49,16 @@ with open(snakemake.log[0], "w") as log_file:
         log_file.write(f"[summarize_all.py] {message}\n")
         log_file.flush()
 
-    log("Invoked via Snakemake")
-    summarize_all(snakemake.input, snakemake.output[0], snakemake.params.tools, log)
-    log("Completed summarize_all Snakemake execution")
+    try:
+        log("Invoked via Snakemake")
+        summarize_all(
+            snakemake.input,
+            snakemake.output[0],
+            snakemake.params.tools,
+            log,
+        )
+        log("Completed summarize_all Snakemake execution")
+    except Exception as error:
+        log(f"Encountered error: {error}")
+        log(traceback.format_exc())
+        raise


### PR DESCRIPTION
## Summary
- wrap Snakemake-driven script logic in try/except blocks to capture errors
- log exceptions and stack traces for easier debugging across all helper scripts

## Testing
- python -m compileall scripts

------
https://chatgpt.com/codex/tasks/task_e_68d5b83bbfac83238913e3e2ac31aea6