### PR TITLE
Filter empty mash species entries

### DIFF
--- a/scripts/parse.py
+++ b/scripts/parse.py
@@ -181,6 +181,7 @@ def parse_mash_winning_sorted_tab(
 
     # Extract species names
     df["species"] = df["full_classification"].apply(_extract_mash_species)
+    df = df[df["species"].fillna("").str.strip() != ""]
 
     # Filter by median multiplicity factor
     if df.empty:


### PR DESCRIPTION
### Motivation
- Mash hit classifications that map to phage or ambiguous labels are converted to an empty species string by `_extract_mash_species`, and those rows were not being removed before sorting/deduplication which caused a blank entry to appear in results (breaking `test_parse_mash_s234_ori`).

### Description
- In `scripts/parse.py` inside `parse_mash_winning_sorted_tab`, add a filter to drop rows where the extracted `species` is empty or whitespace using `df = df[df["species"].fillna("").str.strip() != ""]` so phage/`sp.` hits are removed before downstream processing.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697125fdc7a0832389be3d26fe5fb746)